### PR TITLE
Add Alpine-based Docker image and Compose setup for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ skills/
 - **Strategic Screening** - Opportunity screening and governance evaluation framework
 - **Accessible PPTX** - Accessibility validation and remediation for PowerPoint presentations
 
+## Docker images
+
+- **Claude Code**: `docker/claude-code/` contains a small Alpine-based Docker image and Compose entrypoint for running Claude Code in a container against a mounted repository.
+
 ## Skill format
 
 Each skill should define:

--- a/docker/claude-code/.dockerignore
+++ b/docker/claude-code/.dockerignore
@@ -1,0 +1,5 @@
+**/.git
+**/.venv
+**/node_modules
+**/__pycache__
+**/.pytest_cache

--- a/docker/claude-code/Dockerfile
+++ b/docker/claude-code/Dockerfile
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1
+
+# Small Claude Code runtime image.
+#
+# Mechanically, Alpine is the thin OS layer, the Claude Code native installer
+# drops the agent binary into the non-root user's home directory, and /workspace
+# is the mounted repository the agent operates on.
+ARG ALPINE_VERSION=3.22
+FROM alpine:${ALPINE_VERSION}
+
+ARG USERNAME=claude
+ARG UID=1000
+ARG GID=1000
+ARG CLAUDE_CODE_VERSION=stable
+
+LABEL org.opencontainers.image.title="Claude Code Alpine" \
+      org.opencontainers.image.description="Small Alpine-based image for running the Claude Code CLI in a container" \
+      org.opencontainers.image.source="https://docs.anthropic.com/en/docs/claude-code/getting-started"
+
+ENV HOME=/home/${USERNAME} \
+    PATH=/home/${USERNAME}/.local/bin:/home/${USERNAME}/.claude/local:${PATH} \
+    USE_BUILTIN_RIPGREP=0 \
+    DISABLE_AUTOUPDATER=1
+
+RUN set -eux; \
+    apk add --no-cache \
+      bash \
+      ca-certificates \
+      git \
+      libgcc \
+      libstdc++ \
+      openssh-client \
+      ripgrep; \
+    apk add --no-cache --virtual .fetch-deps curl; \
+    addgroup -g "${GID}" "${USERNAME}"; \
+    adduser -D -h "${HOME}" -s /bin/bash -u "${UID}" -G "${USERNAME}" "${USERNAME}"; \
+    mkdir -p /workspace "${HOME}/.claude" "${HOME}/.local/bin"; \
+    chown -R "${USERNAME}:${USERNAME}" /workspace "${HOME}"; \
+    su "${USERNAME}" -c "curl -fsSL https://claude.ai/install.sh | bash -s ${CLAUDE_CODE_VERSION}"; \
+    su "${USERNAME}" -c "claude --version"; \
+    apk del .fetch-deps
+
+USER ${USERNAME}
+WORKDIR /workspace
+
+VOLUME ["/workspace", "/home/claude/.claude"]
+ENTRYPOINT ["claude"]
+CMD ["--help"]

--- a/docker/claude-code/README.md
+++ b/docker/claude-code/README.md
@@ -1,0 +1,85 @@
+# Claude Code Docker Image
+
+This directory contains a small Alpine-based Docker image for running the
+Claude Code CLI inside a container.
+
+One way to think about the image is: Alpine is the thin operating-system layer,
+the Claude Code native installer provides the agent binary, and `/workspace` is
+the mounted working memory where the agent sees your repository.
+
+## Why Alpine + native installer
+
+Anthropic documents two practical Claude Code install paths:
+
+- `npm install -g @anthropic-ai/claude-code`
+- the native installer: `curl -fsSL https://claude.ai/install.sh | bash`
+
+For a small container, the native installer is the better primitive because the
+final image does not need a Node/npm runtime. Alpine needs `libgcc`, `libstdc++`,
+and `ripgrep` for the native build, so the Dockerfile installs those explicitly
+and sets `USE_BUILTIN_RIPGREP=0`. `curl` is installed only as a temporary build
+dependency and removed after Claude Code is installed.
+
+## Build
+
+From the repository root:
+
+```bash
+docker build -t claude-code:alpine docker/claude-code
+```
+
+To pin a specific Claude Code version:
+
+```bash
+docker build \
+  --build-arg CLAUDE_CODE_VERSION=1.0.58 \
+  -t claude-code:1.0.58 \
+  docker/claude-code
+```
+
+## Run against the current directory
+
+```bash
+docker run --rm -it \
+  -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+  -v "$PWD:/workspace" \
+  -v claude-code-home:/home/claude/.claude \
+  claude-code:alpine
+```
+
+If you authenticate interactively instead of using `ANTHROPIC_API_KEY`, keep the
+named `.claude` volume so the login state survives container restarts.
+
+## Run with Compose
+
+```bash
+WORKSPACE="$PWD" docker compose -f docker/claude-code/compose.yaml run --rm claude-code
+```
+
+## Run a one-shot prompt
+
+```bash
+docker run --rm -it \
+  -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+  -v "$PWD:/workspace" \
+  -v claude-code-home:/home/claude/.claude \
+  claude-code:alpine \
+  --print "Summarize this repository"
+```
+
+## Image contents
+
+The image intentionally includes only the small set of packages Claude Code
+usually needs to operate on a repository:
+
+- `claude-code`, installed by the native installer
+- `bash`
+- `git`
+- `openssh-client`
+- `ca-certificates`
+- `libgcc`, `libstdc++`, and `ripgrep`, required by the Alpine native build path
+
+It runs as a non-root `claude` user and uses `/workspace` as the default working
+directory. Auto-update is disabled by default with `DISABLE_AUTOUPDATER=1` so the
+container behaves like an immutable image; rebuild the image to update Claude
+Code.

--- a/docker/claude-code/compose.yaml
+++ b/docker/claude-code/compose.yaml
@@ -1,0 +1,21 @@
+services:
+  claude-code:
+    build:
+      context: .
+      args:
+        ALPINE_VERSION: "3.22"
+        CLAUDE_CODE_VERSION: stable
+    image: claude-code:alpine
+    stdin_open: true
+    tty: true
+    environment:
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      DISABLE_AUTOUPDATER: "1"
+      USE_BUILTIN_RIPGREP: "0"
+    volumes:
+      - ${WORKSPACE:-../..}:/workspace
+      - claude-code-home:/home/claude/.claude
+    working_dir: /workspace
+
+volumes:
+  claude-code-home:


### PR DESCRIPTION
### Motivation

- Provide a small, reproducible container runtime for the Claude Code CLI so the agent can be run against a mounted repository without requiring Node/npm on the host.
- Document and make it easy to run Claude Code in local and CI environments using an image that behaves like an immutable runtime.

### Description

- Add `docker/claude-code/Dockerfile` which builds a minimal Alpine image, creates a non-root `claude` user, installs runtime deps, runs the native Claude Code installer, and sets the entrypoint to `claude` with a default `--help` CMD. 
- Add `docker/claude-code/.dockerignore` to exclude typical dev artifacts from the build context. 
- Add `docker/claude-code/compose.yaml` with a Compose service that mounts the current repository into `/workspace`, exposes a persistent `.claude` volume, and forwards `ANTHROPIC_API_KEY` and relevant env vars. 
- Add `docker/claude-code/README.md` documenting image rationale, build/run instructions, and usage examples. 
- Update top-level `README.md` to list the new `Docker images` section and the `Claude Code` image entry. 

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20c39a186083228ab676ff2296ab83)